### PR TITLE
improvements: Create DaySelector component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,9 @@ public
 yarn-error.log
 .pnp/
 .pnp.js
+
 # Yarn Integrity file
 .yarn-integrity
+
+# Miscellaneous
+.idea/

--- a/src/components/day-selector.js
+++ b/src/components/day-selector.js
@@ -1,0 +1,42 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+// Styles
+import "../styles/day-selector.css"
+
+/**
+ * Component used to choose the data to filter the data by
+ * @param name            : unique name for the radio selector
+ * @param dayValue        : current value
+ * @param setValue        : radio selector handler
+ * @returns {*}
+ * @constructor
+ */
+const DaySelector = ({ name, dayValue, setValue }) => {
+  return (
+    <div className="control day-selector">
+      <label className="radio">
+        <input type="radio" name={name} checked={dayValue} onClick={() => setValue(true)} />
+        <span className="">Hoy</span>
+      </label>
+      <label className="radio">
+        <input type="radio" name={name} checked={!dayValue} onClick={() => setValue(false)} />
+        <span className="">Ayer</span>
+      </label>
+    </div>
+  )
+}
+
+DaySelector.propTypes = {
+  name: PropTypes.string,
+  dayValue: PropTypes.bool,
+  setValue: PropTypes.func,
+}
+
+DaySelector.defaultProps = {
+  name: 'day',
+  dayValue: true,
+  setValue: () => {},
+}
+
+export default DaySelector

--- a/src/components/origin-chart.js
+++ b/src/components/origin-chart.js
@@ -2,12 +2,13 @@ import React, { useState } from 'react'
 
 import Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
+import DaySelector from "./day-selector"
 
 const OriginChart = ({ provinces }) => {
-  const [yesterday, setYesterday] = useState(false)
+  const [fromToday, setToday] = useState(true)
 
   let provincesToDisplay = [...provinces]
-  if (yesterday) {
+  if (!fromToday) {
     provincesToDisplay = provincesToDisplay.map(province => {
       const cases = [...province.cases]
       cases.pop();
@@ -81,16 +82,11 @@ const OriginChart = ({ provinces }) => {
     <div>
       <h2 className="title">Origen</h2>
 
-      <div className="control">
-        <label className="radio">
-          <input type="radio" name="origin_date" checked={!yesterday} onClick={() => setYesterday(false)} />
-          Hoy
-        </label>
-        <label className="radio">
-          <input type="radio" name="origin_date" checked={yesterday} onClick={() => setYesterday(true)} />
-          Ayer
-        </label>
-      </div>
+      <DaySelector
+        name="origin-day"
+        dayValue={fromToday}
+        setValue={setToday}
+      />
 
       <div className="columns">
         <div className="column is-half">

--- a/src/components/province-distribution.js
+++ b/src/components/province-distribution.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react'
+import DaySelector from "./day-selector"
 
 const ProvinceDistribution = ({ provinces }) => {
   const [filter, setFilter] = useState("")
-  const [yesterday, setYesterday] = useState(false)
+  const [fromToday, setToday] = useState(true)
 
   let provincesToDisplay = [...provinces]
-  if (yesterday) {
+  if (!fromToday) {
     provincesToDisplay = provincesToDisplay.map(province => {
       const cases = [...province.cases]
       cases.pop();
@@ -37,20 +38,15 @@ const ProvinceDistribution = ({ provinces }) => {
     <div>
       <h2 className="title">Distribución por provincia</h2>
 
-      <div className="control">
-        <label className="radio">
-          <input type="radio" name="province_distribution_date" checked={!yesterday} onClick={() => setYesterday(false)} />
-          Hoy
-        </label>
-        <label className="radio">
-          <input type="radio" name="province_distribution_date" checked={yesterday} onClick={() => setYesterday(true)} />
-          Ayer
-        </label>
-      </div>
+      <DaySelector
+        name="province-day"
+        dayValue={fromToday}
+        setValue={setToday}
+      />
 
       <div style={{ maxWidth: '300px' }}>
         <input
-          class="input"
+          className="input"
           type="text"
           placeholder="Filtrar"
           value={filter}
@@ -67,7 +63,7 @@ const ProvinceDistribution = ({ provinces }) => {
           <th>Nuevas muertes</th>
         </thead>
         <tbody>
-          { provincesToDisplay.map((province) => {
+          { provincesToDisplay.map((province, i) => {
             const name = province.name
             const lastUpdate = province.cases[province.cases.length - 1]
             const secondToLast = province.cases[province.cases.length - 2]
@@ -82,7 +78,7 @@ const ProvinceDistribution = ({ provinces }) => {
             total_new_deaths += newDeaths
 
             return (
-              <tr>
+              <tr key={i}>
                 <td>{ name }</td>
                 <td>{ lastUpdate.total_cases }</td>
                 <td>{ newCases }</td>

--- a/src/components/sex-chart.js
+++ b/src/components/sex-chart.js
@@ -2,12 +2,13 @@ import React, { useState } from 'react'
 
 import Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
+import DaySelector from "./day-selector"
 
 const SexChart = ({ sexData }) => {
-  const [yesterday, setYesterday] = useState(false)
+  const [fromToday, setToday] = useState(true)
 
   let sexDataToUse = [...sexData]
-  if (yesterday) {
+  if (!fromToday) {
     sexDataToUse.pop();
   }
 
@@ -62,16 +63,11 @@ const SexChart = ({ sexData }) => {
     <div>
       <h2 className="title">Distribución por sexo</h2>
 
-      <div className="control">
-        <label className="radio">
-          <input type="radio" name="answer" checked={!yesterday} onClick={() => setYesterday(false)} />
-          Hoy
-        </label>
-        <label className="radio">
-          <input type="radio" name="answer" checked={yesterday} onClick={() => setYesterday(true)} />
-          Ayer
-        </label>
-      </div>
+      <DaySelector
+        name="sex-chart-day"
+        dayValue={fromToday}
+        setValue={setToday}
+      />
 
       <div className="columns">
         <div className="column is-half">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,8 +55,6 @@ const IndexPage = () => {
   const sexData = casesQuery.allSexJson.nodes[0].sex
   const allProvinces = casesQuery.allProvincesJson.nodes[0].provinces
 
-  console.log(allCases, sexData, allProvinces)
-
   return (
     <Layout>
       <SEO title="Inicio" />
@@ -66,7 +64,7 @@ const IndexPage = () => {
       <hr />
 
       <MainInfo cases={allCases} />
-      
+
       <hr />
 
       <CaseCharts cases={allCases} />
@@ -86,7 +84,7 @@ const IndexPage = () => {
       <hr />
 
       <GrowthFactor cases={allCases} />
-      
+
     </Layout>
   )
 }

--- a/src/styles/day-selector.css
+++ b/src/styles/day-selector.css
@@ -1,0 +1,12 @@
+
+.day-selector {
+    margin-bottom: 12px;
+}
+
+.day-selector label.radio {
+    margin-right: 8px;
+}
+
+.day-selector label.radio span {
+    margin-left: 6px;
+}


### PR DESCRIPTION
Hi, Luis! Your project is really awesome and it has the potential to help a lot of Dominicans about covid-19 stats. It's amazing that you're using your skills to bring information to others during this outbreak.

I wanted to contribute as soon as I saw the project so here is my first contribution:

## Why?
I noticed that:
1. your day selection logic (Hoy/Ayer) is being used (and repeated) on multiple components.
2. There are a few spacing issues(?) with the radio options

## Solution
- Create a `DaySelector` component to share the today toggling logic between components. Reducing lines of code and adding reusability.
- Refactoring the state logic a bit: rename the state's value and handler to be focused on today rather than yesterday (positive action over negation)

#### [Before]
<img width="308" alt="Screen Shot 2020-03-24 at 1 28 32 PM" src="https://user-images.githubusercontent.com/20671846/77457854-a6ab6980-6dd3-11ea-80c8-d63477e7a0db.png">

#### [After]
<img width="367" alt="Screen Shot 2020-03-24 at 1 28 17 PM" src="https://user-images.githubusercontent.com/20671846/77457860-a9a65a00-6dd3-11ea-95d5-516a59d12c79.png">


## Extras
- Added `.idea/` folder to `/.gitignore` as I'm using Webstorm
- Removed an unused `console.log`
- Created `styles/` folder to store the components' css
- Small fixes to comply with compiler